### PR TITLE
Add PHP login/registration and reorganize files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # OPTISTOCK2.0
 Re haciendo Optistock
+
+## Database Setup
+
+If you are using MySQL, you can create the user table with the following commands:
+
+```sql
+CREATE DATABASE optistock_db;
+USE optistock_db;
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    password VARCHAR(255) NOT NULL
+);
+```
+
+This repository now organizes the site under the `public/` folder with `index.php`, `login.php` and `register.php`.
+The registration and login pages use PHP to store and consultar datos de usuario en MySQL.
+
+Para ejecutar el proyecto de manera local puedes usar el servidor incorporado de PHP:
+
+```bash
+php -S localhost:8000 -t public
+```
+
+Luego abre `http://localhost:8000` en tu navegador.

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OPTISTOCK - Inicio</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; padding-top: 100px; }
+        .btn-login {
+            font-size: 2em;
+            padding: 20px 40px;
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+    <a href="login.php" class="btn-login">Iniciar sesión</a>
+</body>
+</html>

--- a/public/login.php
+++ b/public/login.php
@@ -1,0 +1,50 @@
+<?php
+require_once '../src/db.php';
+$mensaje = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $input = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    $stmt = $conn->prepare("SELECT password FROM users WHERE email = ? OR username = ?");
+    $stmt->bind_param('ss', $input, $input);
+    $stmt->execute();
+    $stmt->bind_result($hash);
+    if ($stmt->fetch() && password_verify($password, $hash)) {
+        $mensaje = 'Inicio de sesión exitoso.';
+    } else {
+        $mensaje = 'Credenciales incorrectas.';
+    }
+    $stmt->close();
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Iniciar sesión</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 400px; margin: auto; padding-top: 50px; }
+        form { display: flex; flex-direction: column; }
+        label { margin-top: 10px; }
+        input { padding: 8px; }
+        button { margin-top: 20px; padding: 10px; background-color: #4CAF50; color: white; border: none; }
+        .mensaje { margin-top: 20px; color: red; }
+    </style>
+</head>
+<body>
+    <h1>Iniciar sesión</h1>
+    <?php if ($mensaje) echo '<p class="mensaje">' . htmlspecialchars($mensaje) . '</p>'; ?>
+    <form method="post" action="">
+        <label for="email">Correo electrónico o usuario</label>
+        <input type="text" id="email" name="email" required>
+
+        <label for="password">Contraseña</label>
+        <input type="password" id="password" name="password" required>
+
+        <button type="submit">Ingresar</button>
+    </form>
+
+    <p>¿No tienes cuenta? <a href="register.php">Regístrate aquí</a></p>
+</body>
+</html>

--- a/public/register.php
+++ b/public/register.php
@@ -1,0 +1,60 @@
+<?php
+require_once '../src/db.php';
+$mensaje = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $confirm = $_POST['confirm'] ?? '';
+
+    if ($password === $confirm) {
+        $hashed = password_hash($password, PASSWORD_DEFAULT);
+        $stmt = $conn->prepare("INSERT INTO users (username, email, password) VALUES (?, ?, ?)");
+        $stmt->bind_param('sss', $username, $email, $hashed);
+        if ($stmt->execute()) {
+            $mensaje = 'Usuario registrado correctamente.';
+        } else {
+            $mensaje = 'Error al registrar: ' . $conn->error;
+        }
+        $stmt->close();
+    } else {
+        $mensaje = 'Las contraseñas no coinciden.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Registro</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 400px; margin: auto; padding-top: 50px; }
+        form { display: flex; flex-direction: column; }
+        label { margin-top: 10px; }
+        input { padding: 8px; }
+        button { margin-top: 20px; padding: 10px; background-color: #4CAF50; color: white; border: none; }
+        .mensaje { margin-top: 20px; color: red; }
+    </style>
+</head>
+<body>
+    <h1>Registrarse</h1>
+    <?php if ($mensaje) echo '<p class="mensaje">' . htmlspecialchars($mensaje) . '</p>'; ?>
+    <form method="post" action="">
+        <label for="username">Usuario</label>
+        <input type="text" id="username" name="username" required>
+
+        <label for="email">Correo electrónico</label>
+        <input type="email" id="email" name="email" required>
+
+        <label for="password">Contraseña</label>
+        <input type="password" id="password" name="password" required>
+
+        <label for="confirm">Confirmar contraseña</label>
+        <input type="password" id="confirm" name="confirm" required>
+
+        <button type="submit">Registrarme</button>
+    </form>
+</body>
+</html>

--- a/src/db.php
+++ b/src/db.php
@@ -1,0 +1,12 @@
+<?php
+// Simple MySQL connection using mysqli
+$host = 'localhost';
+$user = 'root';
+$pass = '';
+$db   = 'optistock_db';
+
+$conn = new mysqli($host, $user, $pass, $db);
+if ($conn->connect_error) {
+    die('Error de conexion: ' . $conn->connect_error);
+}
+?>


### PR DESCRIPTION
## Summary
- move pages into `public/` directory
- convert pages to PHP and connect to MySQL
- add simple `db.php` connection helper
- document running the PHP server in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688aab332934832c9779ee553456a64d